### PR TITLE
fix: allow multiple includes of the same file across independent bran…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,9 @@ class FileIncludeProcessor {
       return "";
     }
 
-    visited.add(includePath);
+    // Create a new set for this branch of the tree
+    const nextVisited = new Set(visited);
+    nextVisited.add(includePath);
 
     const data = jsonData ? this.parseJSON(jsonData, 'include data') : {};
     const fileContent = this.readFile(includePath);
@@ -134,7 +136,7 @@ class FileIncludeProcessor {
     return this.process(
       processedContent,
       path.dirname(includePath),
-      visited,
+      nextVisited,
       newContext
     );
   }
@@ -162,7 +164,9 @@ class FileIncludeProcessor {
         };
 
         const loopContent = this.injectData(loopTemplate, loopContext);
-        return this.process(loopContent, dir, visited, loopContext);
+        const loopVisited = new Set(visited);
+        loopVisited.add(loopPath);
+        return this.process(loopContent, dir, loopVisited, loopContext);
       })
       .join("");
   }


### PR DESCRIPTION
**Summary**
This PR fixes a bug where the FileIncludeProcessor incorrectly triggers a "Circular include detected" error when the same partial or loop template is included multiple times on a single page (as siblings).

**The Problem**
The processor was passing the visited Set by reference throughout the entire recursive tree. Once a file was added to the set, it remained there for all subsequent sibling includes.

**Example that failed before**
```
@@include('header.html', { "title": "A" })
@@include('header.html', { "title": "B" }) // Threw "Circular include detected"
```
**The Solution**
Instead of using a global visited set, we now create a shallow copy (new Set(visited)) for each branch of the recursion.
This preserves protection against actual infinite loops (parent including child which includes parent).
This allows sibling includes to use the same file without conflict.

**Changes**
handleInclude: Now uses nextVisited (a new Set instance) and passes it to the recursive process call.
handleLoop: Now creates a loopVisited Set for each iteration, adding the loopPath to track the loop template itself.
